### PR TITLE
wait for all futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ tokio = { version = "0.2", features = ["full"] }
 pretty_env_logger = "0.4"
 rand = "0.7"
 argh = "0.1"
+futures = "0.3"


### PR DESCRIPTION
- Block wait for all futures to complete.
- Remove the hard time-deadline of 100 secs.
- So now time taken to complete the tests will be whatever time takes upon number of connections and messages.