### PR TITLE
Calculate Incoming ThroughPut as well.

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -72,9 +72,6 @@ impl Connection {
             }
         });
 
-
-
-
         let start = Instant::now();
         let mut acks_count = 0;
         let mut incoming_count = 0;
@@ -160,23 +157,28 @@ async fn requests(topic: String, payload_size: usize, count: usize, requests_tx:
     match delay {
         0 => {
             for _i in 0..count {
-                let payload = vec![0; payload_size];
-                let publish = PublishRaw::new(&topic, qos, payload).unwrap();
-                let publish = Request::PublishRaw(publish);
+                let publish = create_publish(&topic, payload_size, qos);
                 requests_tx.send(publish).await.unwrap();
             }
         },
         _ => {
             let mut interval = time::interval(time::Duration::from_secs(delay));
             for _i in 0..count {
-                let payload = vec![0; payload_size];
-                let publish = PublishRaw::new(&topic, qos, payload).unwrap();
-                let publish = Request::PublishRaw(publish);
-                interval.tick().await;
+                let publish = create_publish(&topic, payload_size, qos);
                 requests_tx.send(publish).await.unwrap();
+                interval.tick().await;
+                
             }
         },
     };
+}
+
+/// create Request
+fn create_publish(topic: &str, payload_size: usize, qos:QoS) -> Request {
+    let payload = vec![0; payload_size];
+    let publish = PublishRaw::new(topic, qos, payload).unwrap();
+    let publish = Request::PublishRaw(publish);
+    publish
 }
 
 /// create subscriptions for a topic.

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -127,13 +127,12 @@ impl Connection {
                 incoming_done = true;
             }
 
-            if outgoing_done {
+            if incoming_done && outgoing_done {
                 break
             }
         }
 
-        // let incoming_throughput = incoming_count * 1000 / incoming_elapsed.as_millis() as usize;
-        let incoming_throughput = 0;
+        let incoming_throughput = (incoming_count * 1000) as f32 / incoming_elapsed.as_millis() as f32;
         let outgoing_throughput = (acks_count * 1000) as f32 / outgoing_elapsed.as_millis() as f32;
 
         println!(


### PR DESCRIPTION
Changes

- Incoming Throughput was not calculated.
- Update in break logic. I am still looking for a `context(golang)` type stuff to kill spawned task with a timeout in `Tokio` ecosystem.  
- Creating an `interval` for `0` time delay is removed as that will keep on yielding.

