### PR TITLE
Timeout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,7 @@ async fn main() {
 
         // Break out of loop, if timeout happens. TODO: Something better
         if start.elapsed().as_secs() == config.kill_time*60 {
-            warn!("Global timeout elapsed.  Test aborting.");
+            warn!("Global timeout elapsed. Aborting Test.");
             break;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use tokio::task;
 mod connection;
 use hdrhistogram::Histogram;
 use structopt::StructOpt;
+use std::time::Instant;
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -101,6 +102,10 @@ struct Config {
     // #[argh(option, short = 'd', default = "0")]
     #[structopt(short = "d", long, default_value = "0")]
     delay: u64,
+
+    // timeout for entire test in minutes
+    #[structopt(short="t", long, default_value="5")]
+    kill_time: u64,
 }
 
 #[tokio::main(core_threads = 4)]
@@ -164,6 +169,7 @@ async fn main() {
 
     let mut cnt = 0;
     let mut hist = Histogram::<u64>::new(4).unwrap();
+    let start = Instant::now();
 
     loop {
         if handles.next().await.is_none() {
@@ -175,6 +181,12 @@ async fn main() {
             hist.add(h).unwrap();
         }
         if cnt == config.connections {
+            break;
+        }
+
+        // Break out of loop, if timeout happens. TODO: Something better
+        if start.elapsed().as_secs() == config.kill_time*60 {
+            warn!("Global timeout elapsed.  Test aborting.");
             break;
         }
     }


### PR DESCRIPTION
```
warning: unused import: `whoami`
  --> src/connection.rs:15:5
   |
15 | use whoami;
   |     ^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: 1 warning emitted

    Finished release [optimized] target(s) in 0.43s
     Running `target/release/mqttwrk`
All connections and subscriptions ok. Elapsed = 0
Id = rumqtt-00000
            Outgoing publishes : Received = 1000000 Throughput = 70313.6 messages/s
            Incoming publishes : Received = 0       Throughput = NaN messages/s
            Reconnects         : 0
# of samples          : 0
99.999'th percentile  : 0
99.99'th percentile   : 0
90 percentile         : 0
50 percentile         : 0
-------------AGGREGATE-----------------
# of samples          : 0
99.999'th percentile  : 0
99.99'th percentile   : 0
90 percentile         : 0
50 percentile         : 0
```

Added a timeout just in case even if single connection does not complete.