### PR TITLE
Redesign amit

### DIFF
--- a/src/bench/connection.rs
+++ b/src/bench/connection.rs
@@ -123,8 +123,6 @@ impl Connection {
         let mut incoming_count = 0;
         let mut hist = Histogram::<u64>::new(4).unwrap();
 
-        // maps to record Publish and PubAck of messages. PKID acts as key
-        let mut pkids_publish: BTreeMap<u16, std::time::Instant> = BTreeMap::new();
         let mut vector: VecDeque<std::time::Instant> = VecDeque::with_capacity(self.config.max_inflight as usize);
         
 
@@ -155,9 +153,7 @@ impl Connection {
             if self.config.publishers == 0 || self.config.count == 0 {
                 continue;
             }
-
-            // println!("Id = {}, {:?}", id, incoming);
-
+            
             match event {
                 Event::Incoming(v) => {
                     match v {

--- a/src/bench/connection.rs
+++ b/src/bench/connection.rs
@@ -219,6 +219,18 @@ impl Connection {
             incoming_throughput,
             reconnects,
         );
+        println!("# of samples          : {}", hist.len());
+        println!(
+            "99.999'th percentile  : {}",
+            hist.value_at_quantile(0.999999)
+        );
+        println!(
+            "99.99'th percentile   : {}",
+            hist.value_at_quantile(0.99999)
+        );
+        println!("90 percentile         : {}", hist.value_at_quantile(0.90));
+        println!("50 percentile         : {}", hist.value_at_quantile(0.5));
+
     }
 }
 


### PR DESCRIPTION
Changes:

- Map to record Outgoing publish for each kid
- Once PubAck is received, time elapsed is calculated.
- Histogram records and summarizes value for each connection.

NOTE: A separate PR will be done for:

- Aggregaration of Histograms
- Progress bar