### PR TITLE
Add workflow to release snap

### DIFF
--- a/.github/workflows/release-snap.yml
+++ b/.github/workflows/release-snap.yml
@@ -1,0 +1,24 @@
+name: Release snap
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-snap:
+    name: Build Snap
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build-snap
+      - name: Publish snap
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        with:
+          snap: ${{ steps.build-snap.outputs.snap }}
+          release: stable

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,37 @@
+name: mqttwrk 
+base: core20
+summary: A MQTT server bench marking tool inspired by wrk.
+website: https://bytebeam.io
+description: Wrk inspired tool for scale and performance testing mqtt brokers.
+confinement: strict
+contact: https://bytebeam.io
+license: Apache-2.0
+title: A MQTT server bench marking tool
+
+adopt-info: mqttwrk
+
+architectures:
+  - build-on: [amd64,i386]
+
+parts:
+  mqttwrk:
+    plugin: rust
+    source: .
+
+    # Extract app version from Cargo.toml and set it as snap's version.
+    override-pull: |
+      snapcraftctl pull
+      version=$(cat Cargo.toml | grep version | head -n1 | cut -d"=" -f2 | awk '{$1=$1};1' | sed -e 's/^"//' -e 's/"$//')
+      sed -i "s/0.1.0/$version/" snapcraft.yaml
+      snapcraftctl set-version $version
+      snapcraftctl set-grade stable
+    
+    # Build a snap here.
+    override-build: |
+      snapcraftctl build
+
+  
+apps:
+  mqttwrk:
+    command: bin/mqttwrk
+    plugs: [network] # in "strict" confinement we need to specify permission to use network.


### PR DESCRIPTION
This commit adds a Github workflow to automate the generation and
release of the snap package and release it to the snap store on
creation of every new tag. Currently it publishes snap to stable
channel but it can be changed by modifying yaml files. It requires
`STORE_LOGIN` secret in the repository to be published successfully.
`STORE_LOGIN` must contain the credential exported in following way.

1. Execute `$ snapcraft export-login --snaps=mqttwrk --acls package_access,package_push,package_update,package_release creds.txt`. 
2. Put contents of `creds.txt` in `STORE_LOGIN`.

Snap can be generated locally using following way.

1. Add keys "`version: <version>`" and "`grade: stable`" to the `snapcraft.yaml` at the level of keys `name`, `base`, `summary` etc.
2. Execute a command `$ snapcraft` in the project directory. It will create a file with .snap extension in current directory.
3. Install snap using `# snap install --dangerous mqttwrk_<version>_multi.snap`.