### PR TITLE
refactor: remove qos2 related code for now because it was cluttering the tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,6 @@ license = "Apache-2.0"
 authors = ["tekjar <raviteja@bytebeam.io>"]
 edition = "2018"
 
-[features]
-default = []
-qos2 = []
-
 [dependencies]
 # rumqttc = {git="https://github.com/bytebeamio/rumqtt.git", branch="master"}
 # rumqttc = { path = "../rumqtt/rumqttc" }

--- a/src/bench/publisher.rs
+++ b/src/bench/publisher.rs
@@ -1,9 +1,7 @@
 use std::{fs, io, sync::Arc, time::Instant};
 
 use hdrhistogram::Histogram;
-use rumqttc::{
-    AsyncClient, Event, EventLoop, Incoming, MqttOptions, Outgoing, QoS, Transport,
-};
+use rumqttc::{AsyncClient, Event, EventLoop, Incoming, MqttOptions, Outgoing, QoS, Transport};
 use tokio::{
     task,
     time::{self, Duration},
@@ -133,7 +131,7 @@ impl Publisher {
                     latencies[pkid as usize] = Some(Instant::now());
                 }
                 Event::Outgoing(Outgoing::PingReq) => {
-                    debug!("ping request") 
+                    debug!("ping request")
                 }
                 _ => (),
             }

--- a/src/bench/subscriber.rs
+++ b/src/bench/subscriber.rs
@@ -143,7 +143,8 @@ impl Subscriber {
             }
         }
 
-        let outgoing_throughput = (publish_count * 1000) as f32 / (last_publish - start).as_millis() as f32;
+        let outgoing_throughput =
+            (publish_count * 1000) as f32 / (last_publish - start).as_millis() as f32;
 
         println!(
             "Id = {}


### PR DESCRIPTION
- move current code to `old-qos2` for future reference