### PR TITLE
refactor: Add tokio::Barrier so all publishers publish simultaneously and other changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "rumqttc"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e17ff7ccc0a8d360c7d5cc8f282604a5592133efbefa47cb62cc2e7df91a65d"
+checksum = "8b616bf8b706c2a6235604f5d93f9578c37d0c6161e13898b68a1da4af2d812c"
 dependencies = [
  "bytes",
  "flume",
@@ -1036,7 +1036,7 @@ dependencies = [
  "log",
  "pollster",
  "rustls-native-certs",
- "rustls-pemfile 0.3.0",
+ "rustls-pemfile",
  "thiserror",
  "tokio",
  "tokio-rustls",
@@ -1075,18 +1075,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.2",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
-dependencies = [
- "base64 0.13.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,33 +10,27 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.43"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "atty"
@@ -57,9 +51,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
@@ -68,22 +62,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitvec"
-version = "0.19.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "bumpalo"
-version = "3.7.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "byteorder"
@@ -93,15 +75,15 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cc"
-version = "1.0.70"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -117,14 +99,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -168,18 +150,18 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -187,12 +169,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if 1.0.0",
- "lazy_static",
 ]
 
 [[package]]
@@ -205,7 +186,7 @@ dependencies = [
  "crossterm_winapi",
  "lazy_static",
  "libc",
- "mio 0.7.13",
+ "mio 0.7.14",
  "parking_lot 0.11.2",
  "signal-hook",
  "winapi",
@@ -218,6 +199,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0da8964ace4d3e4a044fd027919b2237000b24315a37c916f61809f1ff2140b9"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -242,6 +258,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dummy"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf5ff6f74150b0bbb6e6057718a903b3d8f3fc7096c9190fc162ca99d3b2273"
+dependencies = [
+ "darling",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,41 +282,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.0.21"
+name = "fake"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80edafed416a46fb378521624fab1cfa2eb514784fd8921adbe8a8d8321da811"
+checksum = "4d68f517805463f3a896a9d29c1d6ff09d3579ded64a7201b4069f8f9c0d52fd"
 dependencies = [
- "cfg-if 1.0.0",
+ "dummy",
+ "rand",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
  "crc32fast",
- "libc",
  "miniz_oxide",
 ]
 
 [[package]]
 name = "flume"
-version = "0.10.11"
+version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b279436a715a9de95dcd26b151db590a71961cc06e54918b24fe0dd5b7d3fc4"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin 0.9.3",
+ "spin 0.9.4",
 ]
 
 [[package]]
-name = "funty"
-version = "1.1.0"
+name = "fnv"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
+checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -302,9 +337,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
+checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -312,15 +347,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
+checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
+checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -329,18 +364,16 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
+checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
+checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
- "autocfg",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -348,23 +381,22 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
+checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
 
 [[package]]
 name = "futures-task"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
+checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
 
 [[package]]
 name = "futures-util"
-version = "0.3.17"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
+checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
 dependencies = [
- "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -374,29 +406,27 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "hdrhistogram"
-version = "7.3.0"
+version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faa51471caf8069812385974ce947bf4b71a806d7e5a0d1f710af57d6a9a45ad"
+checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
 dependencies = [
  "base64",
  "byteorder",
@@ -434,19 +464,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.10"
+name = "ident_case"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.54"
+name = "itoa"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1866b355d9c878e5e607473cbe3f63282c0b7aad2db1dbebf55076c686918254"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
+name = "js-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -458,29 +500,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lexical-core"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -488,34 +517,39 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
- "autocfg",
 ]
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
 dependencies = [
  "libc",
  "log",
@@ -526,14 +560,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "wasi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -553,6 +587,7 @@ dependencies = [
  "bytes",
  "colored",
  "colour",
+ "fake",
  "flume",
  "futures",
  "hdrhistogram",
@@ -562,6 +597,8 @@ dependencies = [
  "rumqttc",
  "rustyline",
  "rustyline-derive",
+ "serde",
+ "serde_json",
  "structopt",
  "thiserror",
  "tokio",
@@ -572,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "nanorand"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729eb334247daa1803e0a094d0a5c55711b85571179f5ec6e53eccfdf7008958"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom",
 ]
@@ -593,40 +630,37 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.2.1"
+version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
- "bitvec",
- "funty",
- "lexical-core",
  "memchr",
- "version_check",
+ "minimal-lexical",
 ]
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -634,9 +668,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "openssl-probe"
@@ -652,7 +686,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.5",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
@@ -662,14 +696,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.3",
+ "parking_lot_core 0.9.5",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -681,31 +715,31 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ad3879ad3baf4e44784bc6a718a8698867bb991f8ce24d1bcbe2cfb4c3a75e"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -714,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -726,15 +760,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pollster"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb20dcc30536a1508e75d47dd0e399bb2fe7354dcf35cda9127f2bf1ed92e30e"
+checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "pretty_env_logger"
@@ -771,24 +805,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -799,29 +821,22 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "radium"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
-
-[[package]]
 name = "rand"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
- "rand_hc",
 ]
 
 [[package]]
@@ -836,46 +851,38 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
  "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.6"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -884,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "ring"
@@ -923,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.6"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
 dependencies = [
  "log",
  "ring",
@@ -994,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "schannel"
@@ -1005,7 +1012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1048,13 +1055,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
 dependencies = [
  "libc",
- "mio 0.7.13",
+ "mio 0.7.14",
  "signal-hook-registry",
 ]
 
@@ -1069,21 +1107,24 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -1097,18 +1138,12 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -1117,10 +1152,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "structopt"
-version = "0.3.23"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "structopt"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1129,9 +1170,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1142,26 +1183,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.76"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -1177,18 +1212,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.29"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602eca064b2d83369e2b2f34b09c70b605402801927c65c11071ac911d299b88"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.29"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad553cc2c78e8de258400763a647e80e6d1b31ee237275d756f6836d204494c"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1197,29 +1232,29 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.17.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
- "mio 0.8.3",
+ "mio 0.8.5",
  "num_cpus",
- "once_cell",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1228,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.3"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4151fda0cf2798550ad0b34bcfc9b9dcc2a9d2471c895c68f3a8818e54f2389e"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls",
  "tokio",
@@ -1239,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1251,22 +1286,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
+name = "unicode-ident"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "untrusted"
@@ -1282,9 +1317,9 @@ checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "uuid"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d5d669b51467dcf7b2f1a796ce0f955f05f01cafda6c19d6e95f730df29238"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
  "getrandom",
 ]
@@ -1297,15 +1332,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -1315,9 +1344,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.77"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e68338db6becec24d3c7977b5bf8a48be992c934b5d07177e3931f5dc9b076c"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -1325,13 +1354,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.77"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34c405b4f0658583dba0c1c7c9b694f3cac32655db463b56c254a1c75269523"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1340,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.77"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d5a6580be83b19dc570a8f9c324251687ab2184e57086f71625feb57ec77c8"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1350,9 +1379,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.77"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3775a030dc6f5a0afd8a84981a21cc92a781eb429acef9ecce476d0c9113e92"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1363,15 +1392,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.77"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c279e376c7a8e8752a8f1eaa35b7b0bee6bb9fb0cdacfa97cc3f1f289c87e2b4"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.54"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a84d70d1ec7d2da2d26a5bd78f4bca1b8c3254805363ce743b7a05bc30d195a"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1389,10 +1418,11 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.2.1"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524b58fa5a20a2fb3014dd6358b70e6579692a56ef6fce928834e488f42f65e8"
+checksum = "d6631b6a2fd59b1841b622e8f1a7ad241ef0a46f2d580464ce8140ac94cbd571"
 dependencies = [
+ "bumpalo",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1434,12 +1464,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1448,10 +1499,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1460,10 +1523,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1472,7 +1553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
-name = "wyz"
-version = "0.2.0"
+name = "windows_x86_64_msvc"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -110,6 +110,43 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "4.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -282,6 +319,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fake"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,10 +504,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -479,6 +552,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +599,12 @@ name = "libc"
 version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -585,6 +686,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "clap 4.0.32",
  "colored",
  "colour",
  "fake",
@@ -662,7 +764,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -677,6 +779,12 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot"
@@ -929,6 +1037,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,7 +1285,7 @@ version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static",
  "structopt-derive",
 ]
@@ -1174,7 +1296,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.32"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
+checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -129,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.21"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -142,9 +148,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
 dependencies = [
  "os_str_bytes",
 ]
@@ -486,7 +492,7 @@ version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "crossbeam-channel",
  "flate2",
@@ -553,12 +559,12 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -570,7 +576,7 @@ dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -596,9 +602,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.138"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "linux-raw-sys"
@@ -668,7 +674,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -686,7 +692,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "clap 4.0.32",
+ "clap 4.1.1",
  "colored",
  "colour",
  "fake",
@@ -732,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -760,19 +766,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "openssl-probe"
@@ -804,7 +810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.5",
+ "parking_lot_core 0.9.6",
 ]
 
 [[package]]
@@ -823,15 +829,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -988,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1021,6 +1027,8 @@ dependencies = [
 [[package]]
 name = "rumqttc"
 version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e17ff7ccc0a8d360c7d5cc8f282604a5592133efbefa47cb62cc2e7df91a65d"
 dependencies = [
  "bytes",
  "flume",
@@ -1028,7 +1036,7 @@ dependencies = [
  "log",
  "pollster",
  "rustls-native-certs",
- "rustls-pemfile",
+ "rustls-pemfile 0.3.0",
  "thiserror",
  "tokio",
  "tokio-rustls",
@@ -1036,23 +1044,23 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.5"
+version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.20.7"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
 dependencies = [
  "log",
  "ring",
@@ -1067,18 +1075,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.2",
  "schannel",
  "security-framework",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
 dependencies = [
- "base64",
+ "base64 0.13.1",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -1118,12 +1135,11 @@ checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "schannel"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "lazy_static",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1167,18 +1183,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1343,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1358,7 +1374,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1529,11 +1545,10 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.2.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6631b6a2fd59b1841b622e8f1a7ad241ef0a46f2d580464ce8140ac94cbd571"
+checksum = "45dbc71f0cdca27dc261a9bd37ddec174e4a0af2b900b890f378460f745426e3"
 dependencies = [
- "bumpalo",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1571,100 +1586,57 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,9 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "rumqttc"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1514bbc994fc9f36ab7f7ae067b3e4758c717aff7a06c4818c6787cad8b086e1"
+version = "0.19.0"
 dependencies = [
  "bytes",
  "flume",
@@ -1030,7 +1028,7 @@ dependencies = [
  "log",
  "pollster",
  "rustls-native-certs",
- "rustls-pemfile 0.3.0",
+ "rustls-pemfile",
  "thiserror",
  "tokio",
  "tokio-rustls",
@@ -1069,18 +1067,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 1.0.1",
+ "rustls-pemfile",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee86d63972a7c661d1536fefe8c3c8407321c3df668891286de28abcd087360"
-dependencies = [
- "base64",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 bytes = "1"
 anyhow = "1"
 uuid = { version = "1", features = ["v4"] }
-rumqttc = { version = "0.19.0", path = "../rumqtt/rumqttc/"}
+rumqttc = "0.20.0"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ colored = "2.0.0"
 fake = { version = "2.5.0", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.91"
+clap = { version = "4.0.32", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ rustyline = "6.3"
 rustyline-derive = "0.3"
 colour = "0.6.0"
 colored = "2.0.0"
+fake = { version = "2.5.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.91"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 bytes = "1"
 anyhow = "1"
 uuid = { version = "1", features = ["v4"] }
-rumqttc = "0.18.0"
+rumqttc = { version = "0.19.0", path = "../rumqtt/rumqttc/"}
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 rand = "0.8"

--- a/src/bench/mod.rs
+++ b/src/bench/mod.rs
@@ -50,8 +50,7 @@ pub(crate) async fn start(config: BenchConfig) {
         let barrier_handle = barrier_pub.clone();
         let mut publisher = publisher::Publisher::new(id, config).await.unwrap();
         handles.push(task::spawn(async move {
-            barrier_handle.wait().await;
-            Stats::PubStats(publisher.start().await)
+            Stats::PubStats(publisher.start(barrier_handle).await)
         }));
     }
 

--- a/src/bench/mod.rs
+++ b/src/bench/mod.rs
@@ -38,8 +38,7 @@ pub(crate) async fn start(config: BenchConfig) {
         let barrier_handle = barrier_sub.clone();
         let mut subscriber = subscriber::Subscriber::new(id, config).await.unwrap();
         handles.push(task::spawn(async move {
-            barrier_handle.wait().await;
-            Stats::SubStats(subscriber.start().await)
+            Stats::SubStats(subscriber.start(barrier_handle).await)
         }));
     }
 
@@ -87,7 +86,6 @@ pub(crate) fn options(config: Arc<BenchConfig>, id: &str) -> io::Result<MqttOpti
     let mut options = MqttOptions::new(id, &config.server, config.port);
     options.set_keep_alive(Duration::from_secs(config.keep_alive));
     options.set_inflight(config.max_inflight);
-    options.set_connection_timeout(config.conn_timeout);
 
     if let Some(ca_file) = &config.ca_file {
         let ca = fs::read(ca_file)?;

--- a/src/bench/mod.rs
+++ b/src/bench/mod.rs
@@ -74,7 +74,10 @@ pub(crate) async fn start(config: BenchConfig) {
         };
     }
 
-    dbg!(&aggregate_pubstats, &aggregate_substats);
+    println!(
+        "Aggregate PubStats: {:#?}\nAggregate SubStats: {:#?}",
+        &aggregate_pubstats, &aggregate_substats
+    );
 }
 
 pub(crate) fn options(config: Arc<BenchConfig>, id: &str) -> io::Result<MqttOptions> {

--- a/src/bench/mod.rs
+++ b/src/bench/mod.rs
@@ -21,6 +21,26 @@ pub enum ConnectionError {
     Client(#[from] rumqttc::ClientError),
 }
 
+enum Stats {
+    PubStats(PubStats),
+    SubStats(SubStats),
+}
+
+#[derive(Default, Debug)]
+pub struct SubStats {
+    publish_count: u64,
+    puback_count: u64,
+    reconnects: u64,
+    throughput: f32,
+}
+
+#[derive(Default, Debug)]
+pub struct PubStats {
+    outgoing_publish: u64,
+    throughput: f32,
+    reconnects: u64,
+}
+
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
 pub(crate) async fn start(config: BenchConfig) {
     let config = Arc::new(config);
@@ -32,7 +52,7 @@ pub(crate) async fn start(config: BenchConfig) {
         let id = format!("sub-{:05}", i);
         let mut subscriber = subscriber::Subscriber::new(id, config).await.unwrap();
         handles.push(task::spawn(async move {
-            subscriber.start().await;
+            Stats::SubStats(subscriber.start().await)
         }));
     }
 
@@ -42,12 +62,36 @@ pub(crate) async fn start(config: BenchConfig) {
         let id = format!("pub-{:05}", i);
         let mut publisher = publisher::Publisher::new(id, config).await.unwrap();
         handles.push(task::spawn(async move {
-            publisher.start().await;
+            Stats::PubStats(publisher.start().await)
         }));
     }
 
-    // await and consume all futures
-    while handles.next().await.is_some() {}
+    let mut aggregate_substats = SubStats::default();
+    let mut aggregate_pubstats = PubStats::default();
+    let config = Arc::clone(&config);
+    loop {
+        // await and consume all futures
+        if let Some(some_stat) = handles.next().await {
+            match some_stat.unwrap() {
+                Stats::SubStats(substats) => {
+                    aggregate_substats.publish_count += substats.publish_count;
+                    aggregate_substats.puback_count += substats.puback_count;
+                    aggregate_substats.reconnects += substats.reconnects;
+                    aggregate_substats.throughput +=
+                        substats.throughput / config.subscribers as f32;
+                }
+                Stats::PubStats(pubstats) => {
+                    aggregate_pubstats.outgoing_publish += pubstats.outgoing_publish;
+                    aggregate_pubstats.throughput += pubstats.throughput / config.publishers as f32;
+                    aggregate_pubstats.reconnects += pubstats.reconnects;
+                }
+            }
+        } else {
+            break;
+        };
+    }
+
+    dbg!(&aggregate_pubstats, &aggregate_substats);
 }
 
 pub(crate) fn options(config: Arc<BenchConfig>, id: &str) -> io::Result<MqttOptions> {

--- a/src/bench/mod.rs
+++ b/src/bench/mod.rs
@@ -4,7 +4,10 @@ use futures::StreamExt;
 use rumqttc::{MqttOptions, QoS, Transport};
 use tokio::task;
 
-use crate::BenchConfig;
+use crate::{
+    common::{PubStats, Stats, SubStats},
+    BenchConfig,
+};
 
 mod publisher;
 mod subscriber;
@@ -19,26 +22,6 @@ pub enum ConnectionError {
     WrongPacket(rumqttc::Incoming),
     #[error("Client error = {0:?}")]
     Client(#[from] rumqttc::ClientError),
-}
-
-enum Stats {
-    PubStats(PubStats),
-    SubStats(SubStats),
-}
-
-#[derive(Default, Debug)]
-pub struct SubStats {
-    publish_count: u64,
-    puback_count: u64,
-    reconnects: u64,
-    throughput: f32,
-}
-
-#[derive(Default, Debug)]
-pub struct PubStats {
-    outgoing_publish: u64,
-    throughput: f32,
-    reconnects: u64,
 }
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]

--- a/src/bench/publisher.rs
+++ b/src/bench/publisher.rs
@@ -164,32 +164,39 @@ impl Publisher {
 
         let outgoing_throughput = (count * 1000) as f32 / outgoing_elapsed.as_millis() as f32;
 
-        // println!(
-        //     "Id = {}
-        //     Throughputs
-        //     ----------------------------
-        //     Outgoing publishes : {:<7} Throughput = {} messages/s
-        //     Reconnects         : {}
-        //
-        //     Latencies of {} samples
-        //     ----------------------------
-        //     100                 : {}
-        //     99.9999 percentile  : {}
-        //     99.999 percentile   : {}
-        //     90 percentile       : {}
-        //     50 percentile       : {}
-        //     ",
-        //     self.id,
-        //     acks_count,
-        //     outgoing_throughput,
-        //     reconnects,
-        //     histogram.len(),
-        //     histogram.value_at_percentile(100.0),
-        //     histogram.value_at_percentile(99.9999),
-        //     histogram.value_at_percentile(99.999),
-        //     histogram.value_at_percentile(90.0),
-        //     histogram.value_at_percentile(50.0),
-        // );
+        if self.config.show_pub_stat {
+            println!(
+                "Id = {}
+            Throughputs
+            ----------------------------
+            Outgoing publishes : {:<7} Throughput = {} messages/s
+            Reconnects         : {}
+
+            Latencies of {} samples
+            ----------------------------
+            100                 : {}
+            99.9999 percentile  : {}
+            99.999 percentile   : {}
+            90 percentile       : {}
+            50 percentile       : {}
+            ",
+                self.id,
+                acks_count,
+                outgoing_throughput,
+                reconnects,
+                histogram.len(),
+                histogram.value_at_percentile(100.0),
+                histogram.value_at_percentile(99.9999),
+                histogram.value_at_percentile(99.999),
+                histogram.value_at_percentile(90.0),
+                histogram.value_at_percentile(50.0),
+            );
+        }
+
+        // if publish_qos is 0 assume we send all publishes
+        if self.config.publish_qos == 0 {
+            acks_count = self.config.count;
+        }
 
         PubStats {
             outgoing_publish: acks_count as u64,

--- a/src/bench/publisher.rs
+++ b/src/bench/publisher.rs
@@ -7,7 +7,10 @@ use tokio::{
     time::{self, Duration},
 };
 
-use crate::{bench::ConnectionError, BenchConfig};
+use crate::{
+    bench::{ConnectionError, PubStats},
+    BenchConfig,
+};
 
 pub struct Publisher {
     id: String,
@@ -53,7 +56,7 @@ impl Publisher {
         })
     }
 
-    pub async fn start(&mut self) {
+    pub async fn start(&mut self) -> PubStats {
         let qos = get_qos(self.config.publish_qos);
         let inflight = self.config.max_inflight;
         let payload_size = self.config.payload_size;
@@ -87,7 +90,7 @@ impl Publisher {
             acks_expected = 1;
         }
 
-        let mut reconnects: i32 = 0;
+        let mut reconnects: u64 = 0;
         let mut latencies: Vec<Option<Instant>> = vec![None; inflight as usize + 1];
         let mut histogram = Histogram::<u64>::new(4).unwrap();
 
@@ -144,32 +147,38 @@ impl Publisher {
 
         let outgoing_throughput = (count * 1000) as f32 / outgoing_elapsed.as_millis() as f32;
 
-        println!(
-            "Id = {}
-            Throughputs
-            ----------------------------
-            Outgoing publishes : {:<7} Throughput = {} messages/s
-            Reconnects         : {}
+        // println!(
+        //     "Id = {}
+        //     Throughputs
+        //     ----------------------------
+        //     Outgoing publishes : {:<7} Throughput = {} messages/s
+        //     Reconnects         : {}
+        //
+        //     Latencies of {} samples
+        //     ----------------------------
+        //     100                 : {}
+        //     99.9999 percentile  : {}
+        //     99.999 percentile   : {}
+        //     90 percentile       : {}
+        //     50 percentile       : {}
+        //     ",
+        //     self.id,
+        //     acks_count,
+        //     outgoing_throughput,
+        //     reconnects,
+        //     histogram.len(),
+        //     histogram.value_at_percentile(100.0),
+        //     histogram.value_at_percentile(99.9999),
+        //     histogram.value_at_percentile(99.999),
+        //     histogram.value_at_percentile(90.0),
+        //     histogram.value_at_percentile(50.0),
+        // );
 
-            Latencies of {} samples
-            ----------------------------
-            100                 : {}
-            99.9999 percentile  : {}
-            99.999 percentile   : {}
-            90 percentile       : {}
-            50 percentile       : {}
-            ",
-            self.id,
-            acks_count,
-            outgoing_throughput,
+        PubStats {
+            outgoing_publish: acks_count as u64,
+            throughput: outgoing_throughput,
             reconnects,
-            histogram.len(),
-            histogram.value_at_percentile(100.0),
-            histogram.value_at_percentile(99.9999),
-            histogram.value_at_percentile(99.999),
-            histogram.value_at_percentile(90.0),
-            histogram.value_at_percentile(50.0),
-        );
+        }
     }
 }
 

--- a/src/bench/subscriber.rs
+++ b/src/bench/subscriber.rs
@@ -4,7 +4,7 @@ use hdrhistogram::Histogram;
 use rumqttc::{AsyncClient, Event, EventLoop, Incoming, Outgoing};
 
 use crate::{
-    bench::{get_qos, options, ConnectionError},
+    bench::{get_qos, options, ConnectionError, SubStats},
     BenchConfig,
 };
 
@@ -58,7 +58,7 @@ impl Subscriber {
         })
     }
 
-    pub(crate) async fn start(&mut self) {
+    pub(crate) async fn start(&mut self) -> SubStats {
         let required_publish_count = self.config.count * self.config.publishers;
         // total number of publishes received
         let mut publish_count = 0;
@@ -146,33 +146,40 @@ impl Subscriber {
         let outgoing_throughput =
             (publish_count * 1000) as f32 / (last_publish - start).as_millis() as f32;
 
-        println!(
-            "Id = {}
-            Throughputs
-            ----------------------------
-            Incoming publishes : {:<7} Throughput = {} messages/s
-            Outgoing pubacks   : Sent = {}
-            Reconnects         : {}
+        // println!(
+        //     "Id = {}
+        //     Throughputs
+        //     ----------------------------
+        //     Incoming publishes : {:<7} Throughput = {} messages/s
+        //     Outgoing pubacks   : Sent = {}
+        //     Reconnects         : {}
+        //
+        //     Latencies of {} samples
+        //     ----------------------------
+        //     100                 : {}
+        //     99.9999 percentile  : {}
+        //     99.999 percentile   : {}
+        //     90 percentile       : {}
+        //     50 percentile       : {}
+        //     ",
+        //     self.id,
+        //     publish_count,
+        //     outgoing_throughput,
+        //     puback_count,
+        //     reconnects,
+        //     histogram.len(),
+        //     histogram.value_at_percentile(100.0),
+        //     histogram.value_at_percentile(99.9999),
+        //     histogram.value_at_percentile(99.999),
+        //     histogram.value_at_percentile(90.0),
+        //     histogram.value_at_percentile(50.0),
+        // );
 
-            Latencies of {} samples
-            ----------------------------
-            100                 : {}
-            99.9999 percentile  : {}
-            99.999 percentile   : {}
-            90 percentile       : {}
-            50 percentile       : {}
-            ",
-            self.id,
-            publish_count,
-            outgoing_throughput,
+        SubStats {
+            publish_count: publish_count as u64,
             puback_count,
             reconnects,
-            histogram.len(),
-            histogram.value_at_percentile(100.0),
-            histogram.value_at_percentile(99.9999),
-            histogram.value_at_percentile(99.999),
-            histogram.value_at_percentile(90.0),
-            histogram.value_at_percentile(50.0),
-        );
+            throughput: outgoing_throughput,
+        }
     }
 }

--- a/src/bench/subscriber.rs
+++ b/src/bench/subscriber.rs
@@ -149,34 +149,36 @@ impl Subscriber {
         let outgoing_throughput =
             (publish_count * 1000) as f32 / (last_publish - start).as_millis() as f32;
 
-        // println!(
-        //     "Id = {}
-        //     Throughputs
-        //     ----------------------------
-        //     Incoming publishes : {:<7} Throughput = {} messages/s
-        //     Outgoing pubacks   : Sent = {}
-        //     Reconnects         : {}
-        //
-        //     Latencies of {} samples
-        //     ----------------------------
-        //     100                 : {}
-        //     99.9999 percentile  : {}
-        //     99.999 percentile   : {}
-        //     90 percentile       : {}
-        //     50 percentile       : {}
-        //     ",
-        //     self.id,
-        //     publish_count,
-        //     outgoing_throughput,
-        //     puback_count,
-        //     reconnects,
-        //     histogram.len(),
-        //     histogram.value_at_percentile(100.0),
-        //     histogram.value_at_percentile(99.9999),
-        //     histogram.value_at_percentile(99.999),
-        //     histogram.value_at_percentile(90.0),
-        //     histogram.value_at_percentile(50.0),
-        // );
+        if self.config.show_sub_stat {
+            println!(
+                "Id = {}
+            Throughputs
+            ----------------------------
+            Incoming publishes : {:<7} Throughput = {} messages/s
+            Outgoing pubacks   : Sent = {}
+            Reconnects         : {}
+
+            Latencies of {} samples
+            ----------------------------
+            100                 : {}
+            99.9999 percentile  : {}
+            99.999 percentile   : {}
+            90 percentile       : {}
+            50 percentile       : {}
+            ",
+                self.id,
+                publish_count,
+                outgoing_throughput,
+                puback_count,
+                reconnects,
+                histogram.len(),
+                histogram.value_at_percentile(100.0),
+                histogram.value_at_percentile(99.9999),
+                histogram.value_at_percentile(99.999),
+                histogram.value_at_percentile(90.0),
+                histogram.value_at_percentile(50.0),
+            );
+        }
 
         SubStats {
             publish_count: publish_count as u64,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,5 @@
+use rumqttc::{AsyncClient, ConnectionError, Event, EventLoop, Incoming, MqttOptions};
+
 pub enum Stats {
     PubStats(PubStats),
     SubStats(SubStats),
@@ -16,4 +18,32 @@ pub struct PubStats {
     pub outgoing_publish: u64,
     pub throughput: f32,
     pub reconnects: u64,
+}
+
+pub fn get_client(config: MqttOptions) -> (AsyncClient, WrappedEventLoop) {
+    let (client, eventloop) = AsyncClient::new(config, 10);
+    let weventloop = WrappedEventLoop::new(eventloop);
+    (client, weventloop)
+}
+
+pub struct WrappedEventLoop {
+    inner: EventLoop,
+}
+
+// This WrappedEventLoop is used to ignore `Event::Outgoing` type of events as
+// we don't need it during testing
+impl WrappedEventLoop {
+    pub fn new(eventloop: EventLoop) -> Self {
+        WrappedEventLoop { inner: eventloop }
+    }
+
+    pub async fn poll(&mut self) -> Result<Incoming, ConnectionError> {
+        loop {
+            let tmp = self.inner.poll().await?;
+            match tmp {
+                Event::Outgoing(_) => continue,
+                Event::Incoming(v) => return Ok(v),
+            }
+        }
+    }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,0 +1,19 @@
+pub enum Stats {
+    PubStats(PubStats),
+    SubStats(SubStats),
+}
+
+#[derive(Default, Debug)]
+pub struct SubStats {
+    pub publish_count: u64,
+    pub puback_count: u64,
+    pub reconnects: u64,
+    pub throughput: f32,
+}
+
+#[derive(Default, Debug)]
+pub struct PubStats {
+    pub outgoing_publish: u64,
+    pub throughput: f32,
+    pub reconnects: u64,
+}

--- a/src/conformance/basic.rs
+++ b/src/conformance/basic.rs
@@ -1,6 +1,6 @@
 #![allow(unused_imports)]
 
-use crate::conformance::common::{self, WrappedEventLoop};
+use crate::common::{self, WrappedEventLoop};
 use colored::Colorize;
 use rumqttc::{
     matches, AsyncClient, ConnAck, ConnectReturnCode, Event, Incoming, LastWill, MqttOptions,

--- a/src/conformance/common.rs
+++ b/src/conformance/common.rs
@@ -1,29 +1,2 @@
-use rumqttc::{AsyncClient, ConnectionError, Event, EventLoop, Incoming, MqttOptions};
 
-pub fn get_client(config: MqttOptions) -> (AsyncClient, WrappedEventLoop) {
-    let (client, eventloop) = AsyncClient::new(config, 10);
-    let weventloop = WrappedEventLoop::new(eventloop);
-    (client, weventloop)
-}
 
-pub struct WrappedEventLoop {
-    inner: EventLoop,
-}
-
-// This WrappedEventLoop is used to ignore `Event::Outgoing` type of events as
-// we don't need it during testing
-impl WrappedEventLoop {
-    pub fn new(eventloop: EventLoop) -> Self {
-        WrappedEventLoop { inner: eventloop }
-    }
-
-    pub async fn poll(&mut self) -> Result<Incoming, ConnectionError> {
-        loop {
-            let tmp = self.inner.poll().await?;
-            match tmp {
-                Event::Outgoing(_) => continue,
-                Event::Incoming(v) => return Ok(v),
-            }
-        }
-    }
-}

--- a/src/conformance/mod.rs
+++ b/src/conformance/mod.rs
@@ -1,5 +1,4 @@
 mod basic;
-mod common;
 
 use basic::*;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@
 //! - Spawn n clients with publish and subscribe on the same topic (and report thoughput and latencies)
 //! - Spawn n clinets with publishes and 1 subscription to pull all the data (used to simulate a sink in the cloud)
 
+use clap::Parser;
+
 #[macro_use]
 extern crate log;
 #[macro_use]
@@ -18,12 +20,11 @@ mod round;
 mod simulator;
 mod test;
 
-use structopt::StructOpt;
-
-#[derive(Debug, StructOpt)]
-#[structopt(
+#[derive(Debug, Parser)]
+#[command(
     name = "mqttwrk",
-    about = "A MQTT server benchmarking tool inspired by wrk."
+    about = "A MQTT server benchmarking tool inspired by wrk.",
+    version
 )]
 enum Config {
     Bench(BenchConfig),
@@ -33,118 +34,117 @@ enum Config {
     Test,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct BenchConfig {
-    #[structopt(short = "m", long, default_value = "100")]
-    payload_size: usize,
-    /// number of messages (n = 0 is for idle connection to test pings)
-    #[structopt(short = "n", long, default_value = "100")]
-    count: usize,
-    /// server
-    #[structopt(short = "S", long, default_value = "localhost")]
+    /// Broker's address
+    #[arg(short = 'S', long, default_value = "localhost", value_name = "URL")]
     server: String,
-    /// port
-    #[structopt(short = "P", long, default_value = "1883")]
+    /// Port
+    #[arg(short = 'P', long, default_value = "1883")]
     port: u16,
-    /// number of publishers
-    #[structopt(short = "p", default_value = "1")]
+    /// No. of messages per publisher (n = 0 is for idle connection to test pings)
+    #[arg(short = 'n', long, default_value = "100", value_name = "NUM")]
+    count: usize,
+    /// No. of Publishers
+    #[arg(short = 'p', long, default_value = "1", value_name = "NUM")]
     publishers: usize,
-    /// number of subscribers
-    #[structopt(short = "s", default_value = "0")]
+    /// No. of Subscribers
+    #[arg(short = 's', long, default_value = "0", value_name = "NUM")]
     subscribers: usize,
-    /// qos, default 0
-    #[structopt(short = "x", default_value = "1")]
+    /// QoS used for Publishes
+    #[arg(long, default_value = "0", value_name = "QoS")]
     publish_qos: i16,
-    /// qos, default 0
-    #[structopt(short = "y", default_value = "1")]
+    /// Payload size in Bytes
+    #[arg(short = 'm', long, default_value = "100")]
+    payload_size: usize,
+    /// QoS used by Subscriber
+    #[arg(long, default_value = "0", value_name = "QoS")]
     subscribe_qos: i16,
-    /// size of payload
-    /// keep alive
-    #[structopt(short = "k", long, default_value = "10")]
+    /// Keep Alive
+    #[arg(short = 'k', long, default_value = "10")]
     keep_alive: u64,
-    /// max inflight messages
-    #[structopt(short = "i", long, default_value = "100")]
+    /// Max Inflight Messages
+    #[arg(short = 'i', long, default_value = "100")]
     max_inflight: u16,
-    /// path to PEM encoded x509 ca-chain file
-    #[structopt(short = "R", long)]
+    /// Path to PEM encoded x509 ca-chain file
+    #[arg(short = 'R', long)]
     ca_file: Option<String>,
-    /// connection_timeout
-    #[structopt(short = "t", long, default_value = "5")]
+    /// Connection Timeout
+    #[arg(short = 't', long, default_value = "10")]
     conn_timeout: u64,
-    /// message rate. 0 => no throttle
-    #[structopt(short = "r", long, default_value = "0")]
+    /// Message rate per second. (0 means no throttle)
+    #[arg(short = 'r', long, default_value = "0")]
     rate: u64,
 }
 
-#[derive(Clone, Debug, StructOpt)]
-#[structopt(name = "mqttround")]
+#[derive(Clone, Debug, Parser)]
 struct RoundConfig {
-    #[structopt(short = "c", long = "connections")]
+    #[arg(short = 'c', long = "connections")]
     #[allow(dead_code)]
     connections: Option<usize>,
-    #[structopt(short = "i", long = "in-flight", default_value = "100")]
+    #[arg(short = 'i', long = "in-flight", default_value = "100")]
     in_flight: usize,
-    #[structopt(short = "b", long = "broker", default_value = "localhost")]
+    #[arg(short = 'b', long = "broker", default_value = "localhost")]
     broker: String,
-    #[structopt(short = "p", long = "port", default_value = "1883")]
+    #[arg(short = 'p', long = "port", default_value = "1883")]
     port: u16,
-    #[structopt(short = "s", long = "payload-size", default_value = "100")]
+    #[arg(short = 's', long = "payload-size", default_value = "100")]
     payload_size: usize,
-    #[structopt(short = "d", long = "duration", default_value = "10")]
+    #[arg(short = 'd', long = "duration", default_value = "10")]
     duration: u64,
-    #[structopt(short = "n", long = "count")]
+    #[arg(short = 'n', long = "count")]
     max_publishes: Option<u64>,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct SimulatorConfig {
     /// default topic format to which data is published to. `{}` is replaced by publisher_id
-    #[structopt(long, default_value = "/tenants/demo/devices/{}/events/imu/jsonarray")]
+    #[arg(long, default_value = "/tenants/demo/devices/{}/events/imu/jsonarray")]
     topic_format: String,
     /// number of messages (n = 0 is for idle connection to test pings)
-    #[structopt(short = "n", long, default_value = "100")]
+    #[arg(short = 'n', long, default_value = "100")]
     count: usize,
     /// server
-    #[structopt(short = "S", long, default_value = "localhost")]
+    #[arg(short = 'S', long, default_value = "localhost")]
     server: String,
     /// port
-    #[structopt(short = "P", long, default_value = "1883")]
+    #[arg(short = 'P', long, default_value = "1883")]
     port: u16,
     /// number of publishers
-    #[structopt(short = "p", default_value = "1")]
+    #[arg(short = 'p', default_value = "1")]
     publishers: usize,
     /// number of subscribers
-    #[structopt(short = "s", default_value = "0")]
+    #[arg(short = 's', default_value = "0")]
     subscribers: usize,
     /// qos, default 0
-    #[structopt(short = "x", default_value = "1")]
+    #[arg(short = 'x', default_value = "1")]
     publish_qos: i16,
     /// qos, default 0
-    #[structopt(short = "y", default_value = "1")]
+    #[arg(short = 'y', default_value = "1")]
     subscribe_qos: i16,
     /// size of payload
     /// keep alive
-    #[structopt(short = "k", long, default_value = "10")]
+    #[arg(short = 'k', long, default_value = "10")]
     keep_alive: u64,
     /// max inflight messages
-    #[structopt(short = "i", long, default_value = "100")]
+    #[arg(short = 'i', long, default_value = "100")]
     max_inflight: u16,
     /// path to PEM encoded x509 ca-chain file
-    #[structopt(short = "R", long)]
+    #[arg(short = 'R', long)]
     ca_file: Option<String>,
     /// connection_timeout
-    #[structopt(short = "t", long, default_value = "5")]
+    #[arg(short = 't', long, default_value = "5")]
     conn_timeout: u64,
     /// message rate. 0 => no throttle
-    #[structopt(long, default_value = "0")]
+    #[arg(long, default_value = "0")]
     rate_pub: u64,
-    #[structopt(long, default_value = "0")]
+    #[arg(long, default_value = "0")]
     sleep_sub: u64,
 }
 
 fn main() {
     pretty_env_logger::init();
-    let config: Config = Config::from_args();
+    let config: Config = Config::parse();
     match config {
         Config::Bench(config) => {
             bench::start(config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,9 @@ struct RoundConfig {
 
 #[derive(Debug, StructOpt)]
 struct SimulatorConfig {
+    /// default topic format to which data is published to. `{}` is replaced by publisher_id
+    #[structopt(long, default_value = "/tenants/demo/devices/{}/events/imu/jsonarray")]
+    topic_format: String,
     /// number of messages (n = 0 is for idle connection to test pings)
     #[structopt(short = "n", long, default_value = "100")]
     count: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,8 +135,10 @@ struct SimulatorConfig {
     #[structopt(short = "t", long, default_value = "5")]
     conn_timeout: u64,
     /// message rate. 0 => no throttle
-    #[structopt(short = "r", long, default_value = "0")]
-    rate: u64,
+    #[structopt(long, default_value = "0")]
+    rate_pub: u64,
+    #[structopt(long, default_value = "0")]
+    sleep_sub: u64,
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,12 @@ struct BenchConfig {
     /// Message rate per second. (0 means no throttle)
     #[arg(short = 'r', long, default_value = "0")]
     rate: u64,
+    /// Show publisher stats
+    #[arg(long, default_value = "false")]
+    show_pub_stat: bool,
+    /// Show subscriber stats
+    #[arg(long, default_value = "false")]
+    show_sub_stat: bool,
 }
 
 #[derive(Clone, Debug, Parser)]
@@ -140,6 +146,12 @@ struct SimulatorConfig {
     rate_pub: u64,
     #[arg(long, default_value = "0")]
     sleep_sub: u64,
+    /// Show publisher stats
+    #[arg(long, default_value = "false")]
+    show_pub_stat: bool,
+    /// Show subscriber stats
+    #[arg(long, default_value = "false")]
+    show_sub_stat: bool,
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ extern crate log;
 extern crate colour;
 
 mod bench;
+mod common;
 mod conformance;
 mod round;
 mod simulator;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ extern crate colour;
 mod bench;
 mod conformance;
 mod round;
+mod simulator;
 mod test;
 
 use structopt::StructOpt;
@@ -23,10 +24,10 @@ use structopt::StructOpt;
     name = "mqttwrk",
     about = "A MQTT server benchmarking tool inspired by wrk."
 )]
-
 enum Config {
     Bench(BenchConfig),
     Round(RoundConfig),
+    Simulator(SimulatorConfig),
     Conformance,
     Test,
 }
@@ -94,12 +95,56 @@ struct RoundConfig {
     max_publishes: Option<u64>,
 }
 
+#[derive(Debug, StructOpt)]
+struct SimulatorConfig {
+    /// number of messages (n = 0 is for idle connection to test pings)
+    #[structopt(short = "n", long, default_value = "100")]
+    count: usize,
+    /// server
+    #[structopt(short = "S", long, default_value = "localhost")]
+    server: String,
+    /// port
+    #[structopt(short = "P", long, default_value = "1883")]
+    port: u16,
+    /// number of publishers
+    #[structopt(short = "p", default_value = "1")]
+    publishers: usize,
+    /// number of subscribers
+    #[structopt(short = "s", default_value = "0")]
+    subscribers: usize,
+    /// qos, default 0
+    #[structopt(short = "x", default_value = "1")]
+    publish_qos: i16,
+    /// qos, default 0
+    #[structopt(short = "y", default_value = "1")]
+    subscribe_qos: i16,
+    /// size of payload
+    /// keep alive
+    #[structopt(short = "k", long, default_value = "10")]
+    keep_alive: u64,
+    /// max inflight messages
+    #[structopt(short = "i", long, default_value = "100")]
+    max_inflight: u16,
+    /// path to PEM encoded x509 ca-chain file
+    #[structopt(short = "R", long)]
+    ca_file: Option<String>,
+    /// connection_timeout
+    #[structopt(short = "t", long, default_value = "5")]
+    conn_timeout: u64,
+    /// message rate. 0 => no throttle
+    #[structopt(short = "r", long, default_value = "0")]
+    rate: u64,
+}
+
 fn main() {
     pretty_env_logger::init();
     let config: Config = Config::from_args();
     match config {
         Config::Bench(config) => {
             bench::start(config);
+        }
+        Config::Simulator(config) => {
+            simulator::start(config);
         }
         Config::Round(config) => {
             round::start(config).unwrap();

--- a/src/simulator/mod.rs
+++ b/src/simulator/mod.rs
@@ -2,7 +2,7 @@ use std::{fs, io, sync::Arc, time::Duration};
 
 use futures::StreamExt;
 use rumqttc::{MqttOptions, QoS, Transport};
-use tokio::task;
+use tokio::{sync::Barrier, task};
 
 use crate::{
     common::{PubStats, Stats, SubStats},
@@ -28,13 +28,17 @@ pub enum ConnectionError {
 pub(crate) async fn start(config: SimulatorConfig) {
     let config = Arc::new(config);
     let mut handles = futures::stream::FuturesUnordered::new();
+    let barrier_sub = Arc::new(Barrier::new(config.subscribers));
+    let barrier_pub = Arc::new(Barrier::new(config.publishers));
 
     // spawning subscribers
     for i in 0..config.subscribers {
         let config = Arc::clone(&config);
         let id = format!("sub-{:05}", i);
+        let barrier_handle = barrier_sub.clone();
         let mut subscriber = subscriber::Subscriber::new(id, config).await.unwrap();
         handles.push(task::spawn(async move {
+            barrier_handle.wait().await;
             Stats::SubStats(subscriber.start().await)
         }));
     }
@@ -43,8 +47,10 @@ pub(crate) async fn start(config: SimulatorConfig) {
     for i in 0..config.publishers {
         let config = Arc::clone(&config);
         let id = format!("pub-{:05}", i);
+        let barrier_handle = barrier_pub.clone();
         let mut publisher = publisher::Publisher::new(id, config).await.unwrap();
         handles.push(task::spawn(async move {
+            barrier_handle.wait().await;
             Stats::PubStats(publisher.start().await)
         }));
     }
@@ -59,12 +65,11 @@ pub(crate) async fn start(config: SimulatorConfig) {
                     aggregate_substats.publish_count += substats.publish_count;
                     aggregate_substats.puback_count += substats.puback_count;
                     aggregate_substats.reconnects += substats.reconnects;
-                    aggregate_substats.throughput +=
-                        substats.throughput / config.subscribers as f32;
+                    aggregate_substats.throughput += substats.throughput;
                 }
                 Stats::PubStats(pubstats) => {
                     aggregate_pubstats.outgoing_publish += pubstats.outgoing_publish;
-                    aggregate_pubstats.throughput += pubstats.throughput / config.publishers as f32;
+                    aggregate_pubstats.throughput += pubstats.throughput;
                     aggregate_pubstats.reconnects += pubstats.reconnects;
                 }
             }
@@ -74,7 +79,7 @@ pub(crate) async fn start(config: SimulatorConfig) {
     }
 
     println!(
-        "Aggregate PubStats: {:?}\nAggregate SubStats: {:?}",
+        "Aggregate PubStats: {:#?}\nAggregate SubStats: {:#?}",
         &aggregate_pubstats, &aggregate_substats
     );
 }

--- a/src/simulator/mod.rs
+++ b/src/simulator/mod.rs
@@ -38,8 +38,7 @@ pub(crate) async fn start(config: SimulatorConfig) {
         let barrier_handle = barrier_sub.clone();
         let mut subscriber = subscriber::Subscriber::new(id, config).await.unwrap();
         handles.push(task::spawn(async move {
-            barrier_handle.wait().await;
-            Stats::SubStats(subscriber.start().await)
+            Stats::SubStats(subscriber.start(barrier_handle).await)
         }));
     }
 
@@ -50,8 +49,7 @@ pub(crate) async fn start(config: SimulatorConfig) {
         let barrier_handle = barrier_pub.clone();
         let mut publisher = publisher::Publisher::new(id, config).await.unwrap();
         handles.push(task::spawn(async move {
-            barrier_handle.wait().await;
-            Stats::PubStats(publisher.start().await)
+            Stats::PubStats(publisher.start(barrier_handle).await)
         }));
     }
 
@@ -88,7 +86,6 @@ pub(crate) fn options(config: Arc<SimulatorConfig>, id: &str) -> io::Result<Mqtt
     let mut options = MqttOptions::new(id, &config.server, config.port);
     options.set_keep_alive(Duration::from_secs(config.keep_alive));
     options.set_inflight(config.max_inflight);
-    options.set_connection_timeout(config.conn_timeout);
 
     if let Some(ca_file) = &config.ca_file {
         let ca = fs::read(ca_file)?;

--- a/src/simulator/mod.rs
+++ b/src/simulator/mod.rs
@@ -73,7 +73,10 @@ pub(crate) async fn start(config: SimulatorConfig) {
         };
     }
 
-    dbg!(&aggregate_pubstats, &aggregate_substats);
+    println!(
+        "Aggregate PubStats: {:?}\nAggregate SubStats: {:?}",
+        &aggregate_pubstats, &aggregate_substats
+    );
 }
 
 pub(crate) fn options(config: Arc<SimulatorConfig>, id: &str) -> io::Result<MqttOptions> {

--- a/src/simulator/mod.rs
+++ b/src/simulator/mod.rs
@@ -1,0 +1,74 @@
+use std::{fs, io, sync::Arc, time::Duration};
+
+use futures::StreamExt;
+use rumqttc::{MqttOptions, QoS, Transport};
+use tokio::task;
+
+use crate::SimulatorConfig;
+
+mod publisher;
+mod subscriber;
+
+#[derive(thiserror::Error, Debug)]
+pub enum ConnectionError {
+    #[error("IO error = {0:?}")]
+    Io(#[from] io::Error),
+    #[error("Connection error = {0:?}")]
+    Connection(#[from] rumqttc::ConnectionError),
+    #[error("Wrong packet = {0:?}")]
+    WrongPacket(rumqttc::Incoming),
+    #[error("Client error = {0:?}")]
+    Client(#[from] rumqttc::ClientError),
+}
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+pub(crate) async fn start(config: SimulatorConfig) {
+    let config = Arc::new(config);
+    let mut handles = futures::stream::FuturesUnordered::new();
+
+    // spawning subscribers
+    for i in 0..config.subscribers {
+        let config = Arc::clone(&config);
+        let id = format!("sub-{:05}", i);
+        let mut subscriber = subscriber::Subscriber::new(id, config).await.unwrap();
+        handles.push(task::spawn(async move {
+            subscriber.start().await;
+        }));
+    }
+
+    // spawing publishers
+    for i in 0..config.publishers {
+        let config = Arc::clone(&config);
+        let id = format!("pub-{:05}", i);
+        let mut publisher = publisher::Publisher::new(id, config).await.unwrap();
+        handles.push(task::spawn(async move {
+            publisher.start().await;
+        }));
+    }
+
+    // await and consume all futures
+    while handles.next().await.is_some() {}
+}
+
+pub(crate) fn options(config: Arc<SimulatorConfig>, id: &str) -> io::Result<MqttOptions> {
+    let mut options = MqttOptions::new(id, &config.server, config.port);
+    options.set_keep_alive(Duration::from_secs(config.keep_alive));
+    options.set_inflight(config.max_inflight);
+    options.set_connection_timeout(config.conn_timeout);
+
+    if let Some(ca_file) = &config.ca_file {
+        let ca = fs::read(ca_file)?;
+        options.set_transport(Transport::tls(ca, None, None));
+    }
+
+    Ok(options)
+}
+
+/// get QoS level. Default is AtLeastOnce.
+fn get_qos(qos: i16) -> QoS {
+    match qos {
+        0 => QoS::AtMostOnce,
+        1 => QoS::AtLeastOnce,
+        _ => QoS::AtLeastOnce,
+    }
+}

--- a/src/simulator/publisher.rs
+++ b/src/simulator/publisher.rs
@@ -1,0 +1,235 @@
+use std::{fs, io, sync::Arc, time::Instant};
+
+use fake::{Dummy, Fake, Faker};
+use hdrhistogram::Histogram;
+use rumqttc::{AsyncClient, Event, EventLoop, Incoming, MqttOptions, Outgoing, QoS, Transport};
+use serde::Serialize;
+use tokio::{
+    task,
+    time::{self, Duration},
+};
+
+use crate::{bench::ConnectionError, SimulatorConfig};
+
+#[derive(Debug, Serialize, Dummy)]
+struct Imu {
+    ax: f64,
+    ay: f64,
+    az: f64,
+    pitch: f64,
+    roll: f64,
+    yaw: f64,
+    magx: f64,
+    magy: f64,
+    magz: f64,
+}
+
+pub struct Publisher {
+    id: String,
+    config: Arc<SimulatorConfig>,
+    client: AsyncClient,
+    eventloop: EventLoop,
+}
+
+impl Publisher {
+    pub(crate) async fn new(
+        id: String,
+        config: Arc<SimulatorConfig>,
+    ) -> Result<Publisher, ConnectionError> {
+        let (client, mut eventloop) = AsyncClient::new(options(config.clone(), &id)?, 10);
+
+        loop {
+            let event = match eventloop.poll().await {
+                Ok(v) => v,
+                Err(rumqttc::ConnectionError::Timeout(_)) => {
+                    println!("{} reconnecting", id);
+                    time::sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            };
+
+            if let Event::Incoming(v) = event {
+                match v {
+                    Incoming::ConnAck(_) => {
+                        println!("{} connected", id);
+                        break;
+                    }
+                    incoming => return Err(ConnectionError::WrongPacket(incoming)),
+                }
+            }
+        }
+
+        Ok(Publisher {
+            id,
+            config,
+            client,
+            eventloop,
+        })
+    }
+
+    pub async fn start(&mut self) {
+        let qos = get_qos(self.config.publish_qos);
+        let inflight = self.config.max_inflight;
+        let count = self.config.count;
+        let rate = self.config.rate;
+        let id = self.id.clone();
+
+        let start = Instant::now();
+        let mut acks_expected = count;
+        let mut outgoing_elapsed = Duration::from_secs(0);
+        let mut acks_count = 0;
+
+        let topic = format!("/devices/{}/events/imu/json", self.id);
+        let client = self.client.clone();
+
+        // If publish count is 0, don't publish. This is an idle connection
+        // which can be used to test pings
+        if count != 0 {
+            // delay between messages in milliseconds
+            let delay = if rate == 0 { 0 } else { 1000 / rate };
+            task::spawn(async move {
+                requests(topic, count, client, qos, delay).await;
+            });
+        } else {
+            // Just keep this connection alive
+            acks_expected = 1;
+        }
+
+        if self.config.publish_qos == 0 {
+            // only last extra publish is qos 1 for synchronization
+            acks_expected = 1;
+        }
+
+        let mut reconnects: i32 = 0;
+        let mut latencies: Vec<Option<Instant>> = vec![None; inflight as usize + 1];
+        let mut histogram = Histogram::<u64>::new(4).unwrap();
+
+        loop {
+            let event = match self.eventloop.poll().await {
+                Ok(v) => v,
+                Err(e) => {
+                    error!("Id = {}, Connection error = {:?}", self.id, e);
+                    reconnects += 1;
+                    if reconnects >= 1 {
+                        break;
+                    }
+
+                    continue;
+                }
+            };
+
+            debug!("Id = {}, {:?}, count {}", self.id, event, acks_count);
+            match event {
+                Event::Incoming(v) => match v {
+                    Incoming::PubAck(ack) => {
+                        acks_count += 1;
+                        let elapsed = match latencies[ack.pkid as usize] {
+                            Some(instant) => instant.elapsed(),
+                            None => {
+                                warn!("Id = {}, Unsolicited PubAck", ack.pkid);
+                                continue;
+                            }
+                        };
+                        histogram.record(elapsed.as_millis() as u64).unwrap();
+                    }
+                    Incoming::PingResp => {
+                        debug!("ping response")
+                    }
+                    incoming => {
+                        error!("Id = {}, Unexpected incoming packet = {:?}", id, incoming);
+                        break;
+                    }
+                },
+                Event::Outgoing(Outgoing::Publish(pkid)) => {
+                    latencies[pkid as usize] = Some(Instant::now());
+                }
+                Event::Outgoing(Outgoing::PingReq) => {
+                    debug!("ping request")
+                }
+                _ => (),
+            }
+
+            if acks_count >= acks_expected {
+                outgoing_elapsed = start.elapsed();
+                break;
+            }
+        }
+
+        let outgoing_throughput = (count * 1000) as f32 / outgoing_elapsed.as_millis() as f32;
+
+        println!(
+            "Id = {}
+            Throughputs
+            ----------------------------
+            Outgoing publishes : {:<7} Throughput = {} messages/s
+            Reconnects         : {}
+
+            Latencies of {} samples
+            ----------------------------
+            100                 : {}
+            99.9999 percentile  : {}
+            99.999 percentile   : {}
+            90 percentile       : {}
+            50 percentile       : {}
+            ",
+            self.id,
+            acks_count,
+            outgoing_throughput,
+            reconnects,
+            histogram.len(),
+            histogram.value_at_percentile(100.0),
+            histogram.value_at_percentile(99.9999),
+            histogram.value_at_percentile(99.999),
+            histogram.value_at_percentile(90.0),
+            histogram.value_at_percentile(50.0),
+        );
+    }
+}
+
+/// make count number of requests at specified QoS.
+async fn requests(topic: String, count: usize, client: AsyncClient, qos: QoS, delay: u64) {
+    let mut interval = match delay {
+        0 => None,
+        delay => Some(time::interval(time::Duration::from_millis(delay))),
+    };
+
+    for i in 0..count {
+        let payload = serde_json::to_string(&Faker.fake::<Imu>()).unwrap();
+        if let Some(interval) = &mut interval {
+            interval.tick().await;
+        }
+
+        // These errors are usually due to eventloop task being dead. We can ignore the
+        // error here as the failed eventloop task would have already printed an error
+        if let Err(_e) = client.publish(topic.as_str(), qos, false, payload).await {
+            break;
+        }
+
+        info!("published {}", i);
+    }
+}
+
+/// get QoS level. Default is AtLeastOnce.
+fn get_qos(qos: i16) -> QoS {
+    match qos {
+        0 => QoS::AtMostOnce,
+        1 => QoS::AtLeastOnce,
+        2 => QoS::ExactlyOnce,
+        _ => QoS::AtLeastOnce,
+    }
+}
+
+fn options(config: Arc<SimulatorConfig>, id: &str) -> io::Result<MqttOptions> {
+    let mut options = MqttOptions::new(id, &config.server, config.port);
+    options.set_keep_alive(Duration::from_secs(config.keep_alive));
+    options.set_inflight(config.max_inflight);
+    options.set_connection_timeout(config.conn_timeout);
+
+    if let Some(ca_file) = &config.ca_file {
+        let ca = fs::read(ca_file)?;
+        options.set_transport(Transport::tls(ca, None, None));
+    }
+
+    Ok(options)
+}

--- a/src/simulator/publisher.rs
+++ b/src/simulator/publisher.rs
@@ -242,6 +242,17 @@ async fn requests(topic: String, count: usize, client: AsyncClient, qos: QoS, de
 
         info!("published {}", i);
     }
+
+    if qos == QoS::AtMostOnce {
+        let fake_data = vec![dummy_imu(count as u32)];
+        let payload = serde_json::to_string(&fake_data).unwrap();
+        if let Err(_e) = client
+            .publish(topic.as_str(), QoS::AtLeastOnce, false, payload)
+            .await
+        {
+            // TODO
+        }
+    }
 }
 
 /// get QoS level. Default is AtLeastOnce.

--- a/src/simulator/publisher.rs
+++ b/src/simulator/publisher.rs
@@ -193,7 +193,7 @@ impl Publisher {
 
         PubStats {
             outgoing_publish: acks_count as u64,
-            outgoing_throughput,
+            throughput: outgoing_throughput,
             reconnects,
         }
     }

--- a/src/simulator/publisher.rs
+++ b/src/simulator/publisher.rs
@@ -181,32 +181,39 @@ impl Publisher {
 
         let outgoing_throughput = (count * 1000) as f32 / outgoing_elapsed.as_millis() as f32;
 
-        // println!(
-        //     "Id = {}
-        //     Throughputs
-        //     ----------------------------
-        //     Outgoing publishes : {:<7} Throughput = {} messages/s
-        //     Reconnects         : {}
-        //
-        //     Latencies of {} samples
-        //     ----------------------------
-        //     100                 : {}
-        //     99.9999 percentile  : {}
-        //     99.999 percentile   : {}
-        //     90 percentile       : {}
-        //     50 percentile       : {}
-        //     ",
-        //     self.id,
-        //     acks_count,
-        //     outgoing_throughput,
-        //     reconnects,
-        //     histogram.len(),
-        //     histogram.value_at_percentile(100.0),
-        //     histogram.value_at_percentile(99.9999),
-        //     histogram.value_at_percentile(99.999),
-        //     histogram.value_at_percentile(90.0),
-        //     histogram.value_at_percentile(50.0),
-        // );
+        if self.config.show_pub_stat {
+            println!(
+                "Id = {}
+            Throughputs
+            ----------------------------
+            Outgoing publishes : {:<7} Throughput = {} messages/s
+            Reconnects         : {}
+
+            Latencies of {} samples
+            ----------------------------
+            100                 : {}
+            99.9999 percentile  : {}
+            99.999 percentile   : {}
+            90 percentile       : {}
+            50 percentile       : {}
+            ",
+                self.id,
+                acks_count,
+                outgoing_throughput,
+                reconnects,
+                histogram.len(),
+                histogram.value_at_percentile(100.0),
+                histogram.value_at_percentile(99.9999),
+                histogram.value_at_percentile(99.999),
+                histogram.value_at_percentile(90.0),
+                histogram.value_at_percentile(50.0),
+            );
+        }
+
+        // if publish_qos is 0 assume we send all publishes
+        if self.config.publish_qos == 0 {
+            acks_count = self.config.count;
+        }
 
         PubStats {
             outgoing_publish: acks_count as u64,

--- a/src/simulator/publisher.rs
+++ b/src/simulator/publisher.rs
@@ -78,7 +78,7 @@ impl Publisher {
         let qos = get_qos(self.config.publish_qos);
         let inflight = self.config.max_inflight;
         let count = self.config.count;
-        let rate = self.config.rate;
+        let rate = self.config.rate_pub;
         let id = self.id.clone();
 
         let start = Instant::now();

--- a/src/simulator/subscriber.rs
+++ b/src/simulator/subscriber.rs
@@ -5,7 +5,7 @@ use std::{
 
 use hdrhistogram::Histogram;
 use rumqttc::{AsyncClient, Event, EventLoop, Incoming, Outgoing};
-use tokio::time;
+use tokio::{sync::Barrier, time};
 
 use crate::{
     simulator::{get_qos, options, ConnectionError, SubStats},
@@ -26,6 +26,7 @@ impl Subscriber {
         config: Arc<SimulatorConfig>,
     ) -> Result<Subscriber, ConnectionError> {
         let (client, mut eventloop) = AsyncClient::new(options(config.clone(), &id)?, 10);
+        eventloop.network_options.set_connection_timeout(10);
 
         // waiting for connection
         loop {
@@ -65,7 +66,7 @@ impl Subscriber {
         })
     }
 
-    pub async fn start(&mut self) -> SubStats {
+    pub async fn start(&mut self, barrier_handle: Arc<Barrier>) -> SubStats {
         let required_publish_count = self.config.count * self.config.publishers;
         // total number of publishes received
         let mut publish_count = 0;
@@ -80,6 +81,7 @@ impl Subscriber {
         // number of reconnects attempted
         let mut reconnects = 0;
 
+        barrier_handle.wait().await;
         // for the very first publish, to record the starting time of publishes
         loop {
             let event = match self.eventloop.poll().await {

--- a/src/simulator/subscriber.rs
+++ b/src/simulator/subscriber.rs
@@ -1,11 +1,11 @@
 use std::{
     sync::Arc,
-    thread,
     time::{Duration, Instant},
 };
 
 use hdrhistogram::Histogram;
 use rumqttc::{AsyncClient, Event, EventLoop, Incoming, Outgoing};
+use tokio::time;
 
 use crate::{
     simulator::{get_qos, options, ConnectionError},
@@ -146,7 +146,7 @@ impl Subscriber {
                     // slow consumer every 100 messages
                     if seq % 100 == 0 && self.config.sleep_sub != 0 {
                         println!("sleeping {} seconds ...", self.config.sleep_sub);
-                        thread::sleep(Duration::from_secs(self.config.sleep_sub));
+                        time::sleep(Duration::from_secs(self.config.sleep_sub)).await;
                     }
                 }
                 Event::Incoming(Incoming::PingResp) | Event::Outgoing(_) => {}

--- a/src/simulator/subscriber.rs
+++ b/src/simulator/subscriber.rs
@@ -8,7 +8,7 @@ use rumqttc::{AsyncClient, Event, EventLoop, Incoming, Outgoing};
 use tokio::time;
 
 use crate::{
-    simulator::{get_qos, options, ConnectionError},
+    simulator::{get_qos, options, ConnectionError, SubStats},
     SimulatorConfig,
 };
 
@@ -65,7 +65,7 @@ impl Subscriber {
         })
     }
 
-    pub(crate) async fn start(&mut self) {
+    pub async fn start(&mut self) -> SubStats {
         let required_publish_count = self.config.count * self.config.publishers;
         // total number of publishes received
         let mut publish_count = 0;
@@ -160,33 +160,40 @@ impl Subscriber {
         let outgoing_throughput =
             (publish_count * 1000) as f32 / (last_publish - start).as_millis() as f32;
 
-        println!(
-            "Id = {}
-            Throughputs
-            ----------------------------
-            Incoming publishes : {:<7} Throughput = {} messages/s
-            Outgoing pubacks   : Sent = {}
-            Reconnects         : {}
+        // println!(
+        //     "Id = {}
+        //     Throughputs
+        //     ----------------------------
+        //     Incoming publishes : {:<7} Throughput = {} messages/s
+        //     Outgoing pubacks   : Sent = {}
+        //     Reconnects         : {}
+        //
+        //     Latencies of {} samples
+        //     ----------------------------
+        //     100                 : {}
+        //     99.9999 percentile  : {}
+        //     99.999 percentile   : {}
+        //     90 percentile       : {}
+        //     50 percentile       : {}
+        //     ",
+        //     self.id,
+        //     publish_count,
+        //     outgoing_throughput,
+        //     puback_count,
+        //     reconnects,
+        //     histogram.len(),
+        //     histogram.value_at_percentile(100.0),
+        //     histogram.value_at_percentile(99.9999),
+        //     histogram.value_at_percentile(99.999),
+        //     histogram.value_at_percentile(90.0),
+        //     histogram.value_at_percentile(50.0),
+        // );
 
-            Latencies of {} samples
-            ----------------------------
-            100                 : {}
-            99.9999 percentile  : {}
-            99.999 percentile   : {}
-            90 percentile       : {}
-            50 percentile       : {}
-            ",
-            self.id,
-            publish_count,
-            outgoing_throughput,
+        SubStats {
+            publish_count: publish_count as u64,
             puback_count,
             reconnects,
-            histogram.len(),
-            histogram.value_at_percentile(100.0),
-            histogram.value_at_percentile(99.9999),
-            histogram.value_at_percentile(99.999),
-            histogram.value_at_percentile(90.0),
-            histogram.value_at_percentile(50.0),
-        );
+            throughput: outgoing_throughput,
+        }
     }
 }

--- a/src/simulator/subscriber.rs
+++ b/src/simulator/subscriber.rs
@@ -1,0 +1,178 @@
+use std::{sync::Arc, time::Instant};
+
+use hdrhistogram::Histogram;
+use rumqttc::{AsyncClient, Event, EventLoop, Incoming, Outgoing};
+
+use crate::{
+    simulator::{get_qos, options, ConnectionError},
+    SimulatorConfig,
+};
+
+pub struct Subscriber {
+    id: String,
+    config: Arc<SimulatorConfig>,
+    #[allow(dead_code)]
+    client: AsyncClient,
+    eventloop: EventLoop,
+}
+
+impl Subscriber {
+    pub(crate) async fn new(
+        id: String,
+        config: Arc<SimulatorConfig>,
+    ) -> Result<Subscriber, ConnectionError> {
+        let (client, mut eventloop) = AsyncClient::new(options(config.clone(), &id)?, 10);
+
+        // waiting for connection
+        loop {
+            let event = eventloop.poll().await?;
+            if let Event::Incoming(v) = event {
+                match v {
+                    Incoming::ConnAck(_) => break,
+                    incoming => return Err(ConnectionError::WrongPacket(incoming)),
+                }
+            }
+        }
+
+        // subscribing
+        client
+            .subscribe("hello/+/world", get_qos(config.subscribe_qos))
+            .await?;
+
+        // waiting for subscription confirmation
+        loop {
+            let event = eventloop.poll().await?;
+            if let Event::Incoming(v) = event {
+                match v {
+                    Incoming::SubAck(_) => break,
+                    incoming => return Err(ConnectionError::WrongPacket(incoming)),
+                }
+            }
+        }
+
+        Ok(Subscriber {
+            id,
+            config,
+            client,
+            eventloop,
+        })
+    }
+
+    pub(crate) async fn start(&mut self) {
+        let required_publish_count = self.config.count * self.config.publishers;
+        // total number of publishes received
+        let mut publish_count = 0;
+        // total number of pubacks sent
+        let mut puback_count = 0;
+        // when the very first publish arrived
+        let mut start = Instant::now();
+        // when the latest publish arrived
+        let mut last_publish = Instant::now();
+        // to record latencies
+        let mut histogram = Histogram::<u64>::new(4).unwrap();
+        // number of reconnects attempted
+        let mut reconnects = 0;
+
+        // for the very first publish, to record the starting time of publishes
+        loop {
+            let event = match self.eventloop.poll().await {
+                Ok(v) => v,
+                Err(e) => {
+                    error!("Id = {}, Connection error = {:?}", self.id, e);
+
+                    reconnects += 1;
+                    if reconnects >= 1 {
+                        break;
+                    }
+                    continue;
+                }
+            };
+
+            match event {
+                Event::Incoming(Incoming::Publish(_)) => {
+                    publish_count += 1;
+                    start = Instant::now();
+                    last_publish = start;
+                    break;
+                }
+                Event::Incoming(Incoming::PingResp) => {
+                    debug!("ping response");
+                }
+                Event::Outgoing(Outgoing::PingReq) => {
+                    debug!("ping request")
+                }
+                Event::Outgoing(Outgoing::PubAck(_)) => {
+                    puback_count += 1;
+                }
+                packet => {
+                    error!("Id = {}, Unexpected packet = {:?}", self.id, packet,);
+                    continue;
+                }
+            }
+        }
+
+        // for remainging publishes
+        while publish_count < required_publish_count {
+            let event = match self.eventloop.poll().await {
+                Ok(v) => v,
+                Err(e) => {
+                    error!("Id = {}, Connection error = {:?}", self.id, e);
+                    reconnects += 1;
+                    if reconnects >= 2 {
+                        break;
+                    }
+                    continue;
+                }
+            };
+
+            debug!("Id = {}, {:?}, count = {}", self.id, event, publish_count);
+
+            match event {
+                Event::Incoming(Incoming::Publish(_)) => {
+                    publish_count += 1;
+                    histogram
+                        .record(last_publish.elapsed().as_millis() as u64)
+                        .unwrap();
+                    last_publish = Instant::now();
+                }
+                Event::Incoming(Incoming::PingResp) | Event::Outgoing(_) => {}
+                incoming => error!(
+                    "Id = {}, Unexpected incoming packet = {:?}",
+                    self.id, incoming
+                ),
+            }
+        }
+
+        let outgoing_throughput =
+            (publish_count * 1000) as f32 / (last_publish - start).as_millis() as f32;
+
+        println!(
+            "Id = {}
+            Throughputs
+            ----------------------------
+            Incoming publishes : {:<7} Throughput = {} messages/s
+            Outgoing pubacks   : Sent = {}
+            Reconnects         : {}
+
+            Latencies of {} samples
+            ----------------------------
+            100                 : {}
+            99.9999 percentile  : {}
+            99.999 percentile   : {}
+            90 percentile       : {}
+            50 percentile       : {}
+            ",
+            self.id,
+            publish_count,
+            outgoing_throughput,
+            puback_count,
+            reconnects,
+            histogram.len(),
+            histogram.value_at_percentile(100.0),
+            histogram.value_at_percentile(99.9999),
+            histogram.value_at_percentile(99.999),
+            histogram.value_at_percentile(90.0),
+            histogram.value_at_percentile(50.0),
+        );
+    }
+}

--- a/src/simulator/subscriber.rs
+++ b/src/simulator/subscriber.rs
@@ -36,7 +36,10 @@ impl Subscriber {
 
         // subscribing
         client
-            .subscribe("hello/+/world", get_qos(config.subscribe_qos))
+            .subscribe(
+                config.topic_format.replace("{}", &"+"),
+                get_qos(config.subscribe_qos),
+            )
             .await?;
 
         // waiting for subscription confirmation

--- a/src/simulator/subscriber.rs
+++ b/src/simulator/subscriber.rs
@@ -162,34 +162,36 @@ impl Subscriber {
         let outgoing_throughput =
             (publish_count * 1000) as f32 / (last_publish - start).as_millis() as f32;
 
-        // println!(
-        //     "Id = {}
-        //     Throughputs
-        //     ----------------------------
-        //     Incoming publishes : {:<7} Throughput = {} messages/s
-        //     Outgoing pubacks   : Sent = {}
-        //     Reconnects         : {}
-        //
-        //     Latencies of {} samples
-        //     ----------------------------
-        //     100                 : {}
-        //     99.9999 percentile  : {}
-        //     99.999 percentile   : {}
-        //     90 percentile       : {}
-        //     50 percentile       : {}
-        //     ",
-        //     self.id,
-        //     publish_count,
-        //     outgoing_throughput,
-        //     puback_count,
-        //     reconnects,
-        //     histogram.len(),
-        //     histogram.value_at_percentile(100.0),
-        //     histogram.value_at_percentile(99.9999),
-        //     histogram.value_at_percentile(99.999),
-        //     histogram.value_at_percentile(90.0),
-        //     histogram.value_at_percentile(50.0),
-        // );
+        if self.config.show_sub_stat {
+            println!(
+                "Id = {}
+            Throughputs
+            ----------------------------
+            Incoming publishes : {:<7} Throughput = {} messages/s
+            Outgoing pubacks   : Sent = {}
+            Reconnects         : {}
+
+            Latencies of {} samples
+            ----------------------------
+            100                 : {}
+            99.9999 percentile  : {}
+            99.999 percentile   : {}
+            90 percentile       : {}
+            50 percentile       : {}
+            ",
+                self.id,
+                publish_count,
+                outgoing_throughput,
+                puback_count,
+                reconnects,
+                histogram.len(),
+                histogram.value_at_percentile(100.0),
+                histogram.value_at_percentile(99.9999),
+                histogram.value_at_percentile(99.999),
+                histogram.value_at_percentile(90.0),
+                histogram.value_at_percentile(50.0),
+            );
+        }
 
         SubStats {
             publish_count: publish_count as u64,

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -14,6 +14,7 @@ pub async fn start() {
 pub async fn idle_connection() {
     println!("\n{}\n", "Running ping test".yellow().bold().underline());
     let (_client, mut eventloop) = AsyncClient::new(options("test-client", 5, 10), 10);
+    eventloop.network_options.set_connection_timeout(10);
     connect(&mut eventloop).await;
 
     for _i in 0..6 {
@@ -32,6 +33,7 @@ pub async fn idle_connection() {
 pub async fn publishes() {
     println!("\n{}\n", "Running publish test".yellow().bold().underline());
     let (client, mut eventloop) = AsyncClient::new(options("test-client", 5, 10), 10);
+    eventloop.network_options.set_connection_timeout(10);
     connect(&mut eventloop).await;
 
     task::spawn(async move {
@@ -75,6 +77,7 @@ pub async fn subscribe() {
         "Running subscribe test".yellow().bold().underline()
     );
     let (client1, mut eventloop1) = AsyncClient::new(options("test-client-1", 5, 10), 10);
+    eventloop1.network_options.set_connection_timeout(10);
     connect(&mut eventloop1).await;
 
     // Client 1 publish task
@@ -116,6 +119,7 @@ pub async fn subscribe() {
     });
 
     let (client2, mut eventloop2) = AsyncClient::new(options("test-client-2", 5, 10), 10);
+    eventloop2.network_options.set_connection_timeout(10);
     connect(&mut eventloop2).await;
     client2
         .subscribe("hello/+/world", QoS::AtLeastOnce)
@@ -167,7 +171,6 @@ fn options(id: &str, keep_alive: u64, max_inflight: u16) -> MqttOptions {
     let mut options = MqttOptions::new(id, "localhost", 1883);
     options.set_keep_alive(Duration::from_secs(keep_alive));
     options.set_inflight(max_inflight);
-    options.set_connection_timeout(10);
     options.set_clean_session(false);
     options
 }


### PR DESCRIPTION
- Also added a `simulator` which is similar to bench but publishes randomly generated [Imu](https://en.wikipedia.org/wiki/Inertial_measurement_unit) instead of bunch of zeros.
- Use clap instead of structopt, because all features of structopt are now merged into clap and it is now in maintenance mode
- Only show aggregate stats of Publishers and Subscribers
