### PR TITLE
refactor: Calculate throughput using global timer and other improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,7 @@ dependencies = [
  "hdrhistogram",
  "indicatif",
  "log",
+ "nanoid",
  "once_cell",
  "pretty_env_logger",
  "rand",
@@ -723,6 +724,15 @@ dependencies = [
  "tokio-util",
  "uuid",
  "whoami",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
+dependencies = [
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ serde_json = "1.0.91"
 clap = { version = "4.0.32", features = ["derive"] }
 indicatif = "0.17.3"
 once_cell = "1.17.0"
+nanoid = "0.4.0"

--- a/src/bench/mod.rs
+++ b/src/bench/mod.rs
@@ -1,12 +1,12 @@
 use std::{fs, io, sync::Arc, time::Duration};
 
-use futures::StreamExt;
-use indicatif::ProgressBar;
+use futures::future::join;
+use indicatif::{MultiProgress, ProgressBar};
 use rumqttc::{MqttOptions, QoS, Transport};
-use tokio::{sync::Barrier, task};
+use tokio::{sync::Barrier, task::JoinSet, time::Instant};
 
 use crate::{
-    common::{PubStats, Stats, SubStats, PROGRESS_STYLE},
+    common::{PubStats, SubStats, PROGRESS_STYLE},
     BenchConfig, DataType, RunnerConfig,
 };
 
@@ -56,13 +56,38 @@ impl From<BenchConfig> for RunnerConfig {
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
 pub(crate) async fn start(config: impl Into<RunnerConfig>) {
     let config = Arc::new(config.into());
-    let mut handles = futures::stream::FuturesUnordered::new();
-    let barrier_sub = Arc::new(Barrier::new(config.subscribers));
-    let barrier_pub = Arc::new(Barrier::new(config.publishers));
+    dbg!(&config.unique_client_id_prefix);
+    let progress_bar = MultiProgress::new();
+    let pub_bar = progress_bar.add(
+        ProgressBar::new(config.publishers as u64)
+            .with_prefix("Publishers Spawned:")
+            .with_style((*PROGRESS_STYLE).clone()),
+    );
+    pub_bar.enable_steady_tick(Duration::from_secs_f64(0.1));
 
-    let sub_bar = ProgressBar::new(config.subscribers as u64)
-        .with_prefix("Subscribers Spawned:")
-        .with_style((*PROGRESS_STYLE).clone());
+    let sub_bar = progress_bar.add(
+        ProgressBar::new(config.subscribers as u64)
+            .with_prefix("Subscribers Spawned:")
+            .with_style((*PROGRESS_STYLE).clone()),
+    );
+    sub_bar.enable_steady_tick(Duration::from_secs_f64(0.1));
+
+    let (aggregate_pubstats, aggregate_substats) = join(
+        handle_pubs(Arc::clone(&config), pub_bar),
+        handle_subs(Arc::clone(&config), sub_bar),
+    )
+    .await;
+
+    println!(
+        "Aggregate PubStats: {:#?}\nAggregate SubStats: {:#?}",
+        &aggregate_pubstats, &aggregate_substats
+    );
+}
+
+pub async fn handle_subs(config: Arc<RunnerConfig>, sub_bar: ProgressBar) -> (SubStats, f64) {
+    let mut handles_sub = JoinSet::new();
+    let barrier_sub = Arc::new(Barrier::new(config.subscribers + 1));
+    let mut aggregate_substats = SubStats::default();
 
     // spawning subscribers
     for i in 0..config.subscribers {
@@ -71,17 +96,36 @@ pub(crate) async fn start(config: impl Into<RunnerConfig>) {
         let barrier_handle = barrier_sub.clone();
         sub_bar.set_message(format!("spawning {id}"));
         let mut subscriber = subscriber::Subscriber::new(id, config).await.unwrap();
-        handles.push(task::spawn(async move {
-            Stats::SubStats(subscriber.start(barrier_handle).await)
-        }));
+        handles_sub.spawn(async move { subscriber.start(barrier_handle).await });
         sub_bar.inc(1);
     }
+
+    let barrier_sub_handle = barrier_sub.clone();
+    barrier_sub_handle.wait().await;
+    let sub_start_time = Instant::now();
     sub_bar.finish_with_message("Done!");
 
-    // spawing publishers
-    let pub_bar = ProgressBar::new(config.publishers as u64)
-        .with_prefix("Publishers Spawned:")
-        .with_style((*PROGRESS_STYLE).clone());
+    while let Some(Ok(sub_stat)) = handles_sub.join_next().await {
+        aggregate_substats.publish_count += sub_stat.publish_count;
+        aggregate_substats.puback_count += sub_stat.puback_count;
+        aggregate_substats.reconnects += sub_stat.reconnects;
+        aggregate_substats.throughput += sub_stat.throughput;
+    }
+
+    let total_messages = config.subscribers * (config.count * config.publishers);
+    let sub_time = sub_start_time.elapsed().as_secs_f64();
+    let throughput = total_messages as f64 / sub_time;
+
+    (aggregate_substats, throughput)
+}
+
+pub async fn handle_pubs(config: Arc<RunnerConfig>, pub_bar: ProgressBar) -> (PubStats, f64) {
+    let mut handles_pub = JoinSet::new();
+    let barrier_pub = Arc::new(Barrier::new(config.publishers + 1));
+
+    let mut aggregate_pubstats = PubStats::default();
+
+    pub_bar.enable_steady_tick(Duration::from_secs_f64(0.1));
 
     for i in 0..config.publishers {
         let config = Arc::clone(&config);
@@ -89,36 +133,25 @@ pub(crate) async fn start(config: impl Into<RunnerConfig>) {
         let barrier_handle = barrier_pub.clone();
         pub_bar.set_message(format!("spawning {id}"));
         let mut publisher = publisher::Publisher::new(id, config).await.unwrap();
-        handles.push(task::spawn(async move {
-            Stats::PubStats(publisher.start(barrier_handle).await)
-        }));
+        handles_pub.spawn(async move { publisher.start(barrier_handle).await });
         pub_bar.inc(1);
     }
+    let barrier_pub_handle = barrier_pub.clone();
+    barrier_pub_handle.wait().await;
+    let pub_start_time = Instant::now();
     pub_bar.finish_with_message("Done!");
 
-    let mut aggregate_substats = SubStats::default();
-    let mut aggregate_pubstats = PubStats::default();
-    // await and consume all futures
-    while let Some(some_stat) = handles.next().await {
-        match some_stat.unwrap() {
-            Stats::SubStats(substats) => {
-                aggregate_substats.publish_count += substats.publish_count;
-                aggregate_substats.puback_count += substats.puback_count;
-                aggregate_substats.reconnects += substats.reconnects;
-                aggregate_substats.throughput += substats.throughput;
-            }
-            Stats::PubStats(pubstats) => {
-                aggregate_pubstats.outgoing_publish += pubstats.outgoing_publish;
-                aggregate_pubstats.throughput += pubstats.throughput;
-                aggregate_pubstats.reconnects += pubstats.reconnects;
-            }
-        }
+    while let Some(Ok(pub_stat)) = handles_pub.join_next().await {
+        aggregate_pubstats.outgoing_publish += pub_stat.outgoing_publish;
+        aggregate_pubstats.throughput += pub_stat.throughput;
+        aggregate_pubstats.reconnects += pub_stat.reconnects;
     }
 
-    println!(
-        "Aggregate PubStats: {:#?}\nAggregate SubStats: {:#?}",
-        &aggregate_pubstats, &aggregate_substats
-    );
+    let total_messages = config.count * config.publishers;
+    let pub_time = pub_start_time.elapsed().as_secs_f64();
+    let throughput = total_messages as f64 / pub_time;
+
+    (aggregate_pubstats, throughput)
 }
 
 pub(crate) fn options(config: Arc<RunnerConfig>, id: &str) -> io::Result<MqttOptions> {

--- a/src/bench/publisher.rs
+++ b/src/bench/publisher.rs
@@ -11,6 +11,7 @@ use tokio::{
 use crate::{
     bench::ConnectionError,
     bench::{gendata::generate_data, PubStats},
+    common::UNIQUE_ID,
     DataType, RunnerConfig,
 };
 
@@ -76,6 +77,7 @@ impl Publisher {
         let mut acks_count = 0;
 
         let mut topic = self.config.topic_format.replace("{pub_id}", &self.id);
+        topic = topic.replace("{unique_id}", &(*UNIQUE_ID));
         topic = topic.replace("{data_type}", &self.config.payload.to_string());
         let client = self.client.clone();
 

--- a/src/bench/subscriber.rs
+++ b/src/bench/subscriber.rs
@@ -9,6 +9,7 @@ use tokio::{sync::Barrier, time};
 
 use crate::{
     bench::{get_qos, options, ConnectionError, SubStats},
+    common::UNIQUE_ID,
     RunnerConfig,
 };
 
@@ -42,6 +43,7 @@ impl Subscriber {
         }
 
         let mut topic = config.topic_format.replacen("{pub_id}", "+", 1);
+        topic = topic.replace("{unique_id}", &(*UNIQUE_ID));
         topic = topic.replacen("{data_type}", &config.payload.to_string(), 1);
 
         // subscribing

--- a/src/common.rs
+++ b/src/common.rs
@@ -10,11 +10,6 @@ pub static PROGRESS_STYLE: Lazy<indicatif::ProgressStyle> = Lazy::new(|| {
     .progress_chars("##-")
 });
 
-pub enum Stats {
-    PubStats(PubStats),
-    SubStats(SubStats),
-}
-
 #[derive(Default, Debug)]
 pub struct SubStats {
     pub publish_count: u64,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,5 @@
 use indicatif::ProgressStyle;
+use nanoid::nanoid;
 use once_cell::sync::Lazy;
 use rumqttc::{AsyncClient, ConnectionError, Event, EventLoop, Incoming, MqttOptions};
 
@@ -9,6 +10,8 @@ pub static PROGRESS_STYLE: Lazy<indicatif::ProgressStyle> = Lazy::new(|| {
     .expect("progress style template should be correct")
     .progress_chars("##-")
 });
+
+pub static UNIQUE_ID: Lazy<String> = Lazy::new(|| nanoid!(8));
 
 #[derive(Default, Debug)]
 pub struct SubStats {

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ This is useful to uniquely identify different runs of benchmark.
     topic_format: String,
     #[arg(
         long,
-        default_value = "true",
+        default_value_t = true,
         long_help = "\
 If true, prefixes a unique_id to client_id of each publisher and subsciber. 
 Same as `{unique_id}` in `topic_format`.
@@ -141,13 +141,12 @@ This is useful to uniquely identify different runs of benchmark.
     topic_format: String,
     #[arg(
         long,
-        default_value = "true",
+        default_value_t = true,
         long_help = "\
 If true, prefixes a unique_id to client_id of each publisher and subsciber. 
 Same as `{unique_id}` in `topic_format`.
 "
     )]
-    #[arg(long, default_value = "true")]
     unique_client_id_prefix: bool,
 
     #[arg(short = 'k', long, default_value = "10")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,13 +74,12 @@ This is useful to uniquely identify different runs of benchmark.
     topic_format: String,
     #[arg(
         long,
-        default_value_t = true,
         long_help = "\
 If true, prefixes a unique_id to client_id of each publisher and subsciber. 
 Same as `{unique_id}` in `topic_format`.
 "
     )]
-    unique_client_id_prefix: bool,
+    disable_unique_clientid_prefix: bool,
 
     #[arg(short = 'k', long, default_value = "10")]
     keep_alive: u64,
@@ -147,7 +146,7 @@ If true, prefixes a unique_id to client_id of each publisher and subsciber.
 Same as `{unique_id}` in `topic_format`.
 "
     )]
-    unique_client_id_prefix: bool,
+    disable_unique_clientid_prefix: bool,
 
     #[arg(short = 'k', long, default_value = "10")]
     keep_alive: u64,
@@ -180,7 +179,7 @@ pub struct RunnerConfig {
     rate: u64,
     payload: DataType,
     topic_format: String,
-    unique_client_id_prefix: bool,
+    disable_unqiue_clientid_prefix: bool,
     keep_alive: u64,
     max_inflight: u16,
     conn_timeout: u64,

--- a/src/simulator/mod.rs
+++ b/src/simulator/mod.rs
@@ -22,7 +22,7 @@ impl From<SimulatorConfig> for RunnerConfig {
             rate: value.rate,
             payload: value.data_type,
             topic_format: value.topic_format,
-            unique_client_id_prefix: value.unique_client_id_prefix,
+            disable_unqiue_clientid_prefix: value.disable_unique_clientid_prefix,
             keep_alive: value.keep_alive,
             max_inflight: value.max_inflight,
             conn_timeout: value.conn_timeout,


### PR DESCRIPTION
- Add a randomly generated test specific id to client_id
